### PR TITLE
feat(trace-aggregator): add JSON view and search to trace data tree

### DIFF
--- a/frontend/src/components/pages/trace-aggregator/components/trace/TraceAggregatorTraceDataNode.vue
+++ b/frontend/src/components/pages/trace-aggregator/components/trace/TraceAggregatorTraceDataNode.vue
@@ -1,9 +1,30 @@
 <template>
+  <el-row v-if="showToolbar" class="data-toolbar" align="middle">
+    <el-space>
+      <el-input
+          v-model="searchStore.query"
+          placeholder="search in data"
+          clearable
+          style="width: 220px"
+      />
+      <el-switch
+          v-model="searchStore.inValues"
+          class="data-search-switch"
+          inline-prompt
+          active-text="values"
+          inactive-text="keys"
+          :width="70"
+      />
+    </el-space>
+  </el-row>
+
   <el-tree
+      ref="treeRef"
       :data="tree"
       :props="treeProps"
       node-key="key"
       :expand-on-click-node="false"
+      :filter-node-method="filterNode"
       default-expand-all
   >
     <template #default="{ node, data }">
@@ -15,6 +36,11 @@
         >
           {{ node.label }}
         </el-text>
+        <el-space v-if="isParentData(data)">
+          <el-button type="info" @click="onShowNodeJson(data)" link>
+            json
+          </el-button>
+        </el-space>
         <el-space v-if="!isParentData(data)" spacer="|">
           <el-button type="info" @click="onCustomFieldShow(data)" link>
             show
@@ -40,6 +66,22 @@
       <pre>{{ dataDialog.data }}</pre>
     </el-row>
   </el-dialog>
+
+  <el-dialog
+      v-model="jsonDialog.visible"
+      width="80%"
+      top="10px"
+      :append-to-body="true"
+  >
+    <template #header>
+      <el-button type="info" @click="onCopyJson" link>
+        copy
+      </el-button>
+    </template>
+    <el-row style="min-height: 80vh; overflow: auto">
+      <pre>{{ jsonDialog.data }}</pre>
+    </el-row>
+  </el-dialog>
 </template>
 
 <script lang="ts">
@@ -48,6 +90,7 @@ import {
   TraceAggregatorCustomFieldParameter,
 } from "../traces/store/traceAggregatorStore.ts";
 import {TraceAggregatorDetailData} from "./store/traceAggregatorDataStore.ts";
+import {useTraceAggregatorDataSearchStore} from "./store/traceAggregatorDataSearchStore.ts";
 import {copyToClipboard} from "../../../../../utils/helpers.ts";
 import FilterTagsSection from "../tags/FilterTagsSection.vue";
 
@@ -72,14 +115,24 @@ export default defineComponent({
       required: false,
       default: false
     },
+    showToolbar: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
   },
   data() {
     return {
       dataValues: {} as any,
       dataKeys: {} as any,
+      dataNodes: {} as any,
       dataDialog: {
         visible: false,
         data: null,
+      },
+      jsonDialog: {
+        visible: false,
+        data: '',
       },
       treeProps: {
         children: 'children',
@@ -89,6 +142,9 @@ export default defineComponent({
     }
   },
   computed: {
+    searchStore() {
+      return useTraceAggregatorDataSearchStore()
+    },
     tree(): Array<TreeNode> {
       return [this.dataNodeToTree(this.data, 0, 'root')]
     },
@@ -104,6 +160,8 @@ export default defineComponent({
     },
     dataNodeToTree(data: TraceAggregatorDetailData, index: number, postNodeKey: string): TreeNode {
       const nodeKey: string = `${postNodeKey}.${index}.${this.nodeEndKey(data.key)}`
+
+      this.dataNodes[nodeKey] = data
 
       if (!data.children) {
         this.dataValues[nodeKey] = data.value
@@ -164,6 +222,107 @@ export default defineComponent({
       }
 
       this.$emit('onCustomFieldClick', parameters)
+    },
+    buildJson(data: TraceAggregatorDetailData): any {
+      if (!data.children || !data.children.length) {
+        return this.parseValue(data.value)
+      }
+
+      const keys: Array<string> = data.children.map(
+          (child: TraceAggregatorDetailData) => this.nodeEndKey(child.key)
+      )
+
+      // sequential numeric keys starting from zero => treat as an array
+      const isArray: boolean = keys.every((key: string, index: number) => key === String(index))
+
+      if (isArray) {
+        return data.children.map(
+            (child: TraceAggregatorDetailData) => this.buildJson(child)
+        )
+      }
+
+      const result: Record<string, any> = {}
+
+      data.children.forEach((child: TraceAggregatorDetailData) => {
+        result[this.nodeEndKey(child.key)] = this.buildJson(child)
+      })
+
+      return result
+    },
+    parseValue(value: string): any {
+      try {
+        return JSON.parse(value)
+      } catch (e) {
+        return value
+      }
+    },
+    onShowNodeJson(data: TreeNode) {
+      const original: TraceAggregatorDetailData = this.dataNodes[data.key]
+
+      if (!original) {
+        return
+      }
+
+      const keyName: string = original.key ? this.nodeEndKey(original.key) : 'root'
+
+      this.jsonDialog.data = JSON.stringify({[keyName]: this.buildJson(original)}, null, 2)
+      this.jsonDialog.visible = true
+    },
+    onCopyJson() {
+      copyToClipboard(this.jsonDialog.data)
+    },
+    keyMatches(data: TreeNode, query: string): boolean {
+      return typeof data?.key === 'string'
+          && this.nodeEndKey(data.key).toLowerCase().includes(query)
+    },
+    filterNode(value: string, data: TreeNode, node: any): boolean {
+      if (!value) {
+        return true
+      }
+
+      const query = value.toLowerCase()
+
+      if (this.searchStore.inValues) {
+        const nodeValue = this.dataValues[data.key]
+
+        return nodeValue !== undefined
+            && nodeValue !== null
+            && String(nodeValue).toLowerCase().includes(query)
+      }
+
+      // keys mode: show a node if its own key or any ancestor key matches,
+      // so all descendants of a matched branch stay visible
+      let current = node
+
+      while (current) {
+        if (current.data && this.keyMatches(current.data, query)) {
+          return true
+        }
+
+        current = current.parent
+      }
+
+      return false
+    },
+    applyFilter() {
+      // @ts-ignore el-tree exposes filter() via ref
+      this.$refs.treeRef?.filter(this.searchStore.query)
+    },
+  },
+  watch: {
+    'searchStore.query'() {
+      this.applyFilter()
+    },
+    'searchStore.inValues'() {
+      this.applyFilter()
+    },
+    tree() {
+      this.$nextTick(() => this.applyFilter())
+    },
+  },
+  mounted() {
+    if (this.searchStore.query) {
+      this.applyFilter()
     }
   },
 })
@@ -172,5 +331,19 @@ export default defineComponent({
 <style scoped>
 .parent-tree-node {
   color: blue;
+}
+
+.data-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding-left: 10px;
+  padding-bottom: 8px;
+  background-color: var(--el-bg-color);
+}
+
+.data-search-switch {
+  --el-switch-on-color: var(--el-border-color);
+  --el-switch-off-color: var(--el-border-color);
 }
 </style>

--- a/frontend/src/components/pages/trace-aggregator/components/trace/TraceDetail.vue
+++ b/frontend/src/components/pages/trace-aggregator/components/trace/TraceDetail.vue
@@ -1,44 +1,76 @@
 <template>
-  <el-form
-      label-width="80px"
-      label-position="left"
-  >
-    <el-form-item label="Logged at">
-      {{ trace.logged_at }}
-    </el-form-item>
-    <el-form-item label="Id">
-      {{ trace.trace_id }}
-    </el-form-item>
-    <el-form-item v-if="trace.parent_trace_id" label="parent id">
-      {{ trace.parent_trace_id }}
-    </el-form-item>
-    <el-form-item label="Type">
-      <el-tag type="success">
-        {{ trace.type }}
-      </el-tag>
-    </el-form-item>
-    <el-form-item v-if="trace.tags.length" label="Tags">
-      <el-tag v-for="tag in trace.tags" type="warning">
-        {{ tag }}
-      </el-tag>
-    </el-form-item>
-    <el-form-item label="Status">
-      {{ trace.status }}
-    </el-form-item>
-    <el-form-item v-if="trace.duration !== null" label="Duration">
-      {{ trace.duration }}
-    </el-form-item>
-  </el-form>
-  <TraceAggregatorTraceDataNode :data="trace.data"/>
+  <div class="trace-detail">
+    <div class="trace-detail-header">
+      <el-input
+          v-model="searchStore.query"
+          placeholder="search in data"
+          clearable
+          style="width: 220px"
+      />
+      <el-switch
+          v-model="searchStore.inValues"
+          class="data-search-switch"
+          inline-prompt
+          active-text="values"
+          inactive-text="keys"
+          :width="70"
+      />
+      <div class="flex-grow"/>
+      <el-tooltip placement="bottom-end" effect="light">
+        <template #content>
+          <el-form
+              label-width="80px"
+              label-position="left"
+              class="trace-detail-info"
+          >
+            <el-form-item label="Logged at">
+              {{ trace.logged_at }}
+            </el-form-item>
+            <el-form-item label="Id">
+              {{ trace.trace_id }}
+            </el-form-item>
+            <el-form-item v-if="trace.parent_trace_id" label="parent id">
+              {{ trace.parent_trace_id }}
+            </el-form-item>
+            <el-form-item label="Type">
+              <el-tag type="success">
+                {{ trace.type }}
+              </el-tag>
+            </el-form-item>
+            <el-form-item v-if="trace.tags.length" label="Tags">
+              <el-tag v-for="tag in trace.tags" type="warning">
+                {{ tag }}
+              </el-tag>
+            </el-form-item>
+            <el-form-item label="Status">
+              {{ trace.status }}
+            </el-form-item>
+            <el-form-item v-if="trace.duration !== null" label="Duration">
+              {{ trace.duration }}
+            </el-form-item>
+          </el-form>
+        </template>
+        <el-icon size="large" class="trace-detail-info-icon">
+          <Tickets/>
+        </el-icon>
+      </el-tooltip>
+      <slot name="actions"/>
+    </div>
+    <div class="trace-detail-body">
+      <TraceAggregatorTraceDataNode :data="trace.data" :show-toolbar="false"/>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
 import {defineComponent, PropType} from 'vue'
 import {TraceAggregatorDetail} from "./store/traceAggregatorDataStore.ts";
+import {useTraceAggregatorDataSearchStore} from "./store/traceAggregatorDataSearchStore.ts";
 import TraceAggregatorTraceDataNode from "./TraceAggregatorTraceDataNode.vue";
+import {Tickets} from '@element-plus/icons-vue'
 
 export default defineComponent({
-  components: {TraceAggregatorTraceDataNode},
+  components: {TraceAggregatorTraceDataNode, Tickets},
 
   props: {
     trace: {
@@ -46,9 +78,51 @@ export default defineComponent({
       required: true,
     },
   },
+  computed: {
+    searchStore() {
+      return useTraceAggregatorDataSearchStore()
+    },
+  },
 })
 </script>
 
 <style scoped>
+.trace-detail {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
 
+.trace-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+}
+
+.trace-detail-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 0 10px 10px;
+}
+
+.flex-grow {
+  flex-grow: 1;
+}
+
+.trace-detail-info-icon {
+  cursor: pointer;
+}
+
+.trace-detail-info {
+  min-width: 280px;
+}
+
+.data-search-switch {
+  --el-switch-on-color: var(--el-border-color);
+  --el-switch-off-color: var(--el-border-color);
+}
 </style>

--- a/frontend/src/components/pages/trace-aggregator/components/trace/store/traceAggregatorDataSearchStore.ts
+++ b/frontend/src/components/pages/trace-aggregator/components/trace/store/traceAggregatorDataSearchStore.ts
@@ -1,0 +1,15 @@
+import {defineStore} from "pinia";
+
+interface TraceAggregatorDataSearchStoreInterface {
+    query: string,
+    inValues: boolean,
+}
+
+export const useTraceAggregatorDataSearchStore = defineStore('traceAggregatorDataSearchStore', {
+    state: (): TraceAggregatorDataSearchStoreInterface => {
+        return {
+            query: '',
+            inValues: false,
+        }
+    },
+})

--- a/frontend/src/components/pages/trace-aggregator/components/traces/TraceAggregatorTracesTable.vue
+++ b/frontend/src/components/pages/trace-aggregator/components/traces/TraceAggregatorTracesTable.vue
@@ -73,38 +73,59 @@
 
     <el-table-column prop="trace.type" label="Type">
       <template #default="scope">
-        <el-check-tag
-            type="success"
-            :checked="payload.types && payload.types?.indexOf(scope.row.trace.type) !== -1"
-            @click="$emit('onTraceTypeClick', scope.row.trace.type)"
+        <el-tooltip
+            :disabled="scope.row.trace.type.length <= 45"
+            :content="scope.row.trace.type"
+            placement="top"
         >
-          {{ scope.row.trace.type }}
-        </el-check-tag>
+          <el-check-tag
+              type="success"
+              style="white-space: pre-line"
+              :checked="payload.types && payload.types?.indexOf(scope.row.trace.type) !== -1"
+              @click="$emit('onTraceTypeClick', scope.row.trace.type)"
+          >
+            {{ formatLabel(scope.row.trace.type) }}
+          </el-check-tag>
+        </el-tooltip>
       </template>
     </el-table-column>
 
     <el-table-column label="Tags">
       <template #default="scope">
-        <el-check-tag
+        <el-tooltip
             v-for="tag in scope.row.trace.tags"
-            type="warning"
-            :checked="payload.tags && payload.tags?.indexOf(tag) !== -1"
-            @click="$emit('onTraceTagClick', tag)"
+            :disabled="tag.length <= 45"
+            :content="tag"
+            placement="top"
         >
-          {{ tag.slice(0, 40) }}
-        </el-check-tag>
+          <el-check-tag
+              type="warning"
+              style="white-space: pre-line"
+              :checked="payload.tags && payload.tags?.indexOf(tag) !== -1"
+              @click="$emit('onTraceTagClick', tag)"
+          >
+            {{ formatLabel(tag) }}
+          </el-check-tag>
+        </el-tooltip>
       </template>
     </el-table-column>
 
     <el-table-column label="Status">
       <template #default="scope">
-        <el-check-tag
-            type="primary"
-            :checked="payload.statuses && payload.statuses?.indexOf(scope.row.trace.status) !== -1"
-            @click="$emit('onTraceStatusClick', scope.row.trace.status)"
+        <el-tooltip
+            :disabled="scope.row.trace.status.length <= 45"
+            :content="scope.row.trace.status"
+            placement="top"
         >
-          {{ scope.row.trace.status }}
-        </el-check-tag>
+          <el-check-tag
+              type="primary"
+              style="white-space: pre-line"
+              :checked="payload.statuses && payload.statuses?.indexOf(scope.row.trace.status) !== -1"
+              @click="$emit('onTraceStatusClick', scope.row.trace.status)"
+          >
+            {{ formatLabel(scope.row.trace.status) }}
+          </el-check-tag>
+        </el-tooltip>
       </template>
     </el-table-column>
 
@@ -190,6 +211,16 @@ export default defineComponent({
   },
 
   methods: {
+    formatLabel(value: string, limit: number = 45): string {
+      if (value.length <= limit) {
+        return value
+      }
+
+      const rest: string = value.slice(limit)
+      const secondLine: string = rest.length > limit ? rest.slice(0, limit) + '…' : rest
+
+      return value.slice(0, limit) + '\n' + secondLine
+    },
     dataExpandChange(trace: TraceAggregatorItem) {
       if (this.isTraceDataLoaded(trace.trace.trace_id)) {
         return

--- a/frontend/src/components/pages/trace-aggregator/components/tree/TraceAggregatorTraceTree.vue
+++ b/frontend/src/components/pages/trace-aggregator/components/tree/TraceAggregatorTraceTree.vue
@@ -154,7 +154,7 @@
         />
         <div
             v-if="showData"
-            class="row-col right-col"
+            class="right-col"
             style="position: absolute; right: 0; width: 50%;"
         >
           <el-progress
@@ -165,14 +165,13 @@
               :duration="5"
               striped
           />
-          <div v-else style="padding: 10px">
-            <el-row>
+          <TraceDetail v-else :trace="traceAggregatorTreeStore.selectedTrace">
+            <template #actions>
               <el-button @click="onClickCloseData">
                 Close
               </el-button>
-            </el-row>
-            <TraceDetail :trace="traceAggregatorTreeStore.selectedTrace"/>
-          </div>
+            </template>
+          </TraceDetail>
         </div>
       </el-row>
     </div>
@@ -358,6 +357,10 @@ export default defineComponent({
 }
 
 .right-col {
+  height: 90%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
   background-color: var(--el-drawer-bg-color);
   --el-drawer-bg-color: var(--el-dialog-bg-color, var(--el-bg-color));
 }


### PR DESCRIPTION
- add per-branch "json" button showing subtree as JSON (with copy); sequential 0..n keys are rendered as arrays
- add data tree search with keys/values toggle, persisted in a store so the filter survives detalization switches in the Tree tab; key matches keep all descendants visible
- rework Tree tab detail panel: fixed header (search + info tooltip with trace metadata + Close), tree-only scroll
- truncate type/tag/status labels to 45 chars (two lines) with full text in a tooltip