### PR TITLE
build(php): migrate extensions from PECL to PIE; make xhprof optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "ext-mongodb": "*",
         "ext-pcntl": "*",
         "ext-pdo": "*",
-        "ext-xhprof": "*",
         "guzzlehttp/guzzle": "^7.2",
         "ifksco/openapi-generator": "dev-master",
         "laravel/framework": "^12",
@@ -35,6 +34,9 @@
         "nunomaduro/collision": "^8.8",
         "phpunit/phpunit": "^11",
         "spatie/laravel-ignition": "^2.0"
+    },
+    "suggest": {
+        "ext-xhprof": "Enables XHProf profiling; install the xhprof PHP extension manually"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee57a09647b4629b21b158ba199386e2",
+    "content-hash": "faffeb7d6029b99693d9f66c80f6843c",
     "packages": [
         {
             "name": "brick/math",
@@ -12950,8 +12950,7 @@
         "php": "^8.4",
         "ext-mongodb": "*",
         "ext-pcntl": "*",
-        "ext-pdo": "*",
-        "ext-xhprof": "*"
+        "ext-pdo": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -17,39 +17,31 @@ RUN apt-get update \
         pkg-config \
         libssl-dev
 
-RUN pecl install \
-        redis \
-        imagick \
-        mongodb-1.21.0 \
-        zstd \
-        zip \
-        xhprof
+# PIE (PHP Installer for Extensions) — replacement for PECL
+RUN curl -fSL --connect-timeout 10 --retry 3 \
+        https://github.com/php/pie/releases/latest/download/pie.phar \
+        -o /usr/local/bin/pie \
+    && chmod +x /usr/local/bin/pie
+
+# Third-party extensions via PIE (installs and enables them)
+RUN pie install phpredis/phpredis \
+    && pie install imagick/imagick \
+    && pie install mongodb/mongodb-extension:^1.21 \
+    && pie install msgpack/msgpack-php \
+    && pie install kjdev/zstd
 
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 
+# Bundled (core) extensions
 RUN docker-php-ext-install \
         gd \
         pdo \
         pdo_mysql \
         bcmath \
         exif \
-        sockets
-
-RUN docker-php-ext-enable \
-        redis \
-        imagick \
-        zstd \
-        bcmath \
-        exif \
         sockets \
-        mongodb \
-        zip
-
-# pcntl
-RUN pecl pcntl && docker-php-ext-install pcntl
-
-# msgpack
-RUN pecl install msgpack && docker-php-ext-enable msgpack
+        zip \
+        pcntl
 
 # sconcur
 ARG BUILD_TIME=1
@@ -65,12 +57,7 @@ FROM php_base AS php_app
 ARG APP_ENV
 
 RUN if [ "$APP_ENV" = "local" ] ; then \
-    curl -fSL --connect-timeout 10 --retry 3 \
-        https://xdebug.org/files/xdebug-3.5.3.tgz \
-        -o /tmp/xdebug.tgz \
-    && pecl install /tmp/xdebug.tgz \
-    && rm /tmp/xdebug.tgz \
-    && docker-php-ext-enable xdebug \
+    pie install xdebug/xdebug:^3.5 \
 ; fi
 
 # Install composer

--- a/docker/php/conf/php-workers.ini
+++ b/docker/php/conf/php-workers.ini
@@ -1,4 +1,1 @@
-[xhprof]
-extension=xhprof.so
-
 memory_limit=512M

--- a/docker/php/conf/php.ini
+++ b/docker/php/conf/php.ini
@@ -4,7 +4,4 @@ xdebug.idekey = PHPSTORM
 xdebug.start_with_request = 1
 xdebug.log_level = 0
 
-[xhprof]
-extension=xhprof.so
-
 memory_limit=512M


### PR DESCRIPTION
Install third-party PHP extensions with PIE (php/pie) instead of PECL: phpredis, imagick, mongodb (pinned ^1.21 to match mongodb/mongodb ^1.17), msgpack and zstd; xdebug via PIE in the local stage. Move zip and pcntl to the bundled docker-php-ext-install and drop the now-redundant docker-php-ext-enable block (PIE and the core installer enable on their own).

xhprof is dropped from the image and from composer require, added as a composer suggest instead; the extension=xhprof.so lines are removed from the mounted php.ini/php-workers.ini so PHP no longer fails to load it.