### PR TITLE
chore: pin sconcur extension to the composer.lock version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Keep the Docker build context small. The php image only needs composer.lock,
+# the receiver image only needs servers/receiver — none of the below.
+.git
+.idea
+vendor/
+**/node_modules/
+**/.gocache/

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/tinker": "^2.8",
         "mongodb/laravel-mongodb": "^5.5",
         "mongodb/mongodb": "^1.17",
-        "sconcur/sconcur": "dev-master",
+        "sconcur/sconcur": "^0.4.0",
         "slogger/laravel": "dev-master",
         "spiral/roadrunner-cli": "^2.7",
         "spiral/roadrunner-http": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "faffeb7d6029b99693d9f66c80f6843c",
+    "content-hash": "da3540e48278f8e05b4c3279d40ae05f",
     "packages": [
         {
             "name": "brick/math",
@@ -4198,16 +4198,16 @@
         },
         {
             "name": "sconcur/sconcur",
-            "version": "dev-master",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sprust/sconcur.git",
-                "reference": "6ff3d2c4cd345d8847cf402e60f9077fce4827db"
+                "reference": "33e260cbdc889cf97f4d08ee25c1b092f8bca9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sprust/sconcur/zipball/6ff3d2c4cd345d8847cf402e60f9077fce4827db",
-                "reference": "6ff3d2c4cd345d8847cf402e60f9077fce4827db",
+                "url": "https://api.github.com/repos/sprust/sconcur/zipball/33e260cbdc889cf97f4d08ee25c1b092f8bca9f6",
+                "reference": "33e260cbdc889cf97f4d08ee25c1b092f8bca9f6",
                 "shasum": ""
             },
             "require": {
@@ -4230,9 +4230,10 @@
             "suggest": {
                 "ext-pcntl": "Required for graceful shutdown of the HTTP server (SIGTERM/SIGINT handling); the server otherwise runs until the process is killed"
             },
-            "default-branch": true,
             "bin": [
-                "bin/sconcur-server"
+                "bin/sconcur-load",
+                "bin/sconcur-server",
+                "bin/sconcur-status"
             ],
             "type": "library",
             "autoload": {
@@ -4253,9 +4254,9 @@
             "description": "PHP concurrency library backed by an extension written in Go",
             "support": {
                 "issues": "https://github.com/sprust/sconcur/issues",
-                "source": "https://github.com/sprust/sconcur/tree/master"
+                "source": "https://github.com/sprust/sconcur/tree/v0.4.0"
             },
-            "time": "2026-06-20T10:48:58+00:00"
+            "time": "2026-06-26T20:39:26+00:00"
         },
         {
             "name": "slogger/laravel",
@@ -12950,7 +12951,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "ifksco/openapi-generator": 20,
-        "sconcur/sconcur": 20,
         "slogger/laravel": 20,
         "sprust/rr-monitor-laravel": 20
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
     container_name: sl-php-fpm
     restart: unless-stopped
     build:
-      context: ./docker/php
+      context: .
+      dockerfile: docker/php/Dockerfile
       target: php_app
       args:
         - APP_ENV=${APP_ENV}
         - GROUP_ID=${DOCKER_GROUP_ID}
         - USER_ID=${DOCKER_USER_ID}
-        - BUILD_TIME=${BUILD_TIME:-1}
     depends_on:
       mysql:
         condition: service_started
@@ -44,12 +44,12 @@ services:
     container_name: sl-workers
     restart: unless-stopped
     build:
-      context: ./docker/php
+      context: .
+      dockerfile: docker/php/Dockerfile
       target: php_workers
       args:
         - GROUP_ID=${DOCKER_GROUP_ID}
         - USER_ID=${DOCKER_USER_ID}
-        - BUILD_TIME=${BUILD_TIME:-1}
     depends_on:
       mysql:
         condition: service_started
@@ -84,7 +84,6 @@ services:
       args:
         - GROUP_ID=${DOCKER_GROUP_ID}
         - USER_ID=${DOCKER_USER_ID}
-        - BUILD_TIME=${BUILD_TIME:-1}
     depends_on:
       mysql:
         condition: service_started

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
         zsh \
         git \
         curl \
+        jq \
         zip \
         unzip \
         wget \
@@ -43,12 +44,14 @@ RUN docker-php-ext-install \
         zip \
         pcntl
 
-# sconcur
-ARG BUILD_TIME=1
-RUN curl -fSL --connect-timeout 10 --retry 3 -4 \
-    https://github.com/sprust/sconcur/releases/latest/download/sconcur.so \
-    -o $(php-config --extension-dir)/sconcur.so \
-    && echo "extension=sconcur.so" > /usr/local/etc/php/conf.d/docker-php-ext-sconcur.ini
+# sconcur — extension .so pinned to the composer.lock version (build context is the repo root)
+COPY composer.lock ./
+RUN set -eux; \
+    version="$(jq -r '.packages[] | select(.name=="sconcur/sconcur") | .version' composer.lock | sed 's/^v//')"; \
+    curl -fSL --retry 3 -4 \
+        "https://github.com/sprust/sconcur/releases/download/v${version}/sconcur.so" \
+        -o "$(php-config --extension-dir)/sconcur.so"; \
+    echo "extension=sconcur.so" > /usr/local/etc/php/conf.d/docker-php-ext-sconcur.ini
 
 EXPOSE 9000
 

--- a/docker/receiver/Dockerfile
+++ b/docker/receiver/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.26
 
-ARG BUILD_TIME=1
-
 RUN mkdir /app
 
 WORKDIR /app

--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ setup:
 	make restart
 
 build:
-	BUILD_TIME=$(shell date +%s) docker-compose build
+	docker-compose build
 
 up:
 	docker-compose up -d
@@ -159,9 +159,16 @@ receiver-build:
 	docker-compose up -d --force-recreate $(RECEIVER_SERVICE)
 
 sconcur-update:
-	make stop
-	make build
-	docker-compose up -d php-fpm
+	docker-compose up -d $(PHP_FPM_SERVICE) $(WORKERS_SERVICE)
 	make composer c='update sconcur/sconcur'
+	make sconcur-load
 	make restart
+	make sconcur-status
+
+sconcur-load:
+	docker-compose exec -u root -e XDEBUG_MODE=off $(PHP_FPM_SERVICE) sh -c './vendor/bin/sconcur-load "$$(php-config --extension-dir)/sconcur.so"'
+	docker-compose exec -u root -e XDEBUG_MODE=off $(WORKERS_SERVICE) sh -c './vendor/bin/sconcur-load "$$(php-config --extension-dir)/sconcur.so"'
+
+sconcur-status:
+	docker-compose exec -e XDEBUG_MODE=off $(PHP_FPM_SERVICE) ./vendor/bin/sconcur-status
 


### PR DESCRIPTION
- composer: require sconcur/sconcur ^0.4.0 instead of dev-master
- Dockerfile: download sconcur.so for the exact version read from composer.lock (via jq) instead of the rolling `latest` release; build context moved to the repo root so composer.lock is reachable, jq added
- docker-compose: php-fpm/workers build from the root context
- add .dockerignore to keep the root build context small
- makefile: `make sconcur-update` now updates the package and loads the matching extension into php-fpm and workers via vendor/bin/sconcur-load, then verifies with sconcur-status; drop the obsolete BUILD_TIME cache-bust